### PR TITLE
feat: update overlay style so that it stays fixed when scrolling the screen

### DIFF
--- a/src/components/organisms/SideBar.tsx
+++ b/src/components/organisms/SideBar.tsx
@@ -26,6 +26,9 @@ export function SideBar() {
       open={showMenu}
       overlay={showOverlay}
       onClose={handleCloseOnMobile}
+      overlayProps={{
+        className: 'fixed',
+      }}
     >
       <FilterHeroesForm />
       <HeroesBattle />


### PR DESCRIPTION
**Objetivo**
O overlay do menu lateral deve ficar fixo quando o usuário scrollar a tela.

**Changelog**
[feat: update overlay style so that it stays fixed when scrolling the screen](https://github.com/pedrop07/whoStronger/commit/ab8c1feee9a1e6fa7534a23e04d0f27ffe8b327f) 

**Evidências visuais**
N/A

**Checklist antes de abrir o PR**
- [ ] Existe alguma breaking change sendo intrudoduzida?
- [x] Funcionalidade foi testada manualmente?
- [x] Tags adicionadas?